### PR TITLE
reformatted some cases, and added new test cases

### DIFF
--- a/emulators/aws-ec2/tests/cli/ec2/create-egress-only-internet-gateway.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/create-egress-only-internet-gateway.rst
@@ -1,21 +1,53 @@
-**To create an egress-only Internet gateway**
+**Example 1: To create an egress-only internet gateway**
 
-This example creates an egress-only Internet gateway for the specified VPC.
+The following ``create-egress-only-internet-gateway`` example creates an egress-only internet gateway for the specified VPC. ::
 
-Command::
-
-  aws ec2 create-egress-only-internet-gateway --vpc-id vpc-0c62a468
+    aws ec2 create-egress-only-internet-gateway \
+        --vpc-id vpc-0c62a468
 
 Output::
 
-  {
-    "EgressOnlyInternetGateway": {
-        "EgressOnlyInternetGatewayId": "eigw-015e0e244e24dfe8a", 
-        "Attachments": [
-            {
-                "State": "attached", 
-                "VpcId": "vpc-0c62a468"
-            }
-        ]
+    {
+        "EgressOnlyInternetGateway": {
+            "EgressOnlyInternetGatewayId": "eigw-015e0e244e24dfe8a",
+            "Attachments": [
+                {
+                    "State": "attached",
+                    "VpcId": "vpc-0c62a468"
+                }
+            ],
+            "Tags": []
+        }
     }
-  }
+
+For more information, see `Enable outbound IPv6 traffic using an egress-only internet gateway <https://docs.aws.amazon.com/vpc/latest/userguide/egress-only-internet-gateway.html>`__ in the *Amazon VPC User Guide*.
+
+**Example 2: To create an egress-only internet gateway with a Name tag**
+
+The following ``create-egress-only-internet-gateway`` example creates an egress-only internet gateway and assigns it a name tag at creation time using ``--tag-specifications``. ::
+
+    aws ec2 create-egress-only-internet-gateway \
+        --vpc-id vpc-0c62a468 \
+        --tag-specifications ResourceType=egress-only-internet-gateway,Tags=[{Key=Name,Value=my-eigw}]
+
+Output::
+
+    {
+        "EgressOnlyInternetGateway": {
+            "EgressOnlyInternetGatewayId": "eigw-024c1f9358EXAMPLE",
+            "Attachments": [
+                {
+                    "State": "attached",
+                    "VpcId": "vpc-0c62a468"
+                }
+            ],
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "my-eigw"
+                }
+            ]
+        }
+    }
+
+For more information, see `Enable outbound IPv6 traffic using an egress-only internet gateway <https://docs.aws.amazon.com/vpc/latest/userguide/egress-only-internet-gateway.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/create-internet-gateway.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/create-internet-gateway.rst
@@ -1,6 +1,25 @@
-**To create an internet gateway**
+**Example 1: To create an internet gateway**
 
-The following ``create-internet-gateway`` example creates an internet gateway with the tag ``Name=my-igw``. ::
+The following ``create-internet-gateway`` example creates an internet gateway. ::
+
+    aws ec2 create-internet-gateway
+
+Output::
+
+    {
+        "InternetGateway": {
+            "Attachments": [],
+            "InternetGatewayId": "igw-0d0fb496b3EXAMPLE",
+            "OwnerId": "123456789012",
+            "Tags": []
+        }
+    }
+
+For more information, see `Internet gateways <https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html>`__ in the *Amazon VPC User Guide*.
+
+**Example 2: To create an internet gateway with a Name tag**
+
+The following ``create-internet-gateway`` example creates an internet gateway and assigns it a name tag at creation time using ``--tag-specifications``. ::
 
     aws ec2 create-internet-gateway \
         --tag-specifications ResourceType=internet-gateway,Tags=[{Key=Name,Value=my-igw}]

--- a/emulators/aws-ec2/tests/cli/ec2/create-key-pair.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/create-key-pair.rst
@@ -1,14 +1,39 @@
-**To create a key pair**
+**Example 1: To create an RSA key pair**
 
-This example creates a key pair named ``MyKeyPair``.
+The following ``create-key-pair`` example creates a 2048-bit RSA key pair named ``MyKeyPair`` and saves the private key directly to a file. ::
 
-Command::
+    aws ec2 create-key-pair \
+        --key-name MyKeyPair \
+        --query "KeyMaterial" \
+        --output text > MyKeyPair.pem
 
-  aws ec2 create-key-pair --key-name MyKeyPair
+Output::
 
-The output is an ASCII version of the private key and key fingerprint. You need to save the key to a file.
+    {
+        "KeyFingerprint": "1f:51:ae:28:bf:89:e9:d8:1f:25:5d:37:2d:7d:b8:ca:9f:f5:f1:6f",
+        "KeyMaterial": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA0Z3VS5JJcds3xHn/ygWep4PAtEsHnEb9X5OKIQhwLajgboEt\n...\n-----END RSA PRIVATE KEY-----",
+        "KeyName": "MyKeyPair",
+        "KeyPairId": "key-0123456789abcdef0"
+    }
 
-For more information, see `Using Key Pairs`_ in the *AWS Command Line Interface User Guide*.
+For more information, see `Create a key pair using Amazon EC2 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html>`__ in the *Amazon EC2 User Guide*.
 
-.. _`Using Key Pairs`: http://docs.aws.amazon.com/cli/latest/userguide/cli-ec2-keypairs.html
+**Example 2: To create an ED25519 key pair**
 
+The following ``create-key-pair`` example creates an ED25519 key pair named ``MyKeyPair``. ED25519 keys are shorter and offer improved security and performance compared to RSA keys. ::
+
+    aws ec2 create-key-pair \
+        --key-name MyKeyPair \
+        --key-type ed25519
+
+Output::
+
+    {
+        "KeyFingerprint": "SHA256:EXAMPLEaHfnJe8EXAMPLE0sD5EXAMPLE2/EXAMPLE",
+        "KeyMaterial": "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAA...\n-----END OPENSSH PRIVATE KEY-----",
+        "KeyName": "MyKeyPair",
+        "KeyPairId": "key-0123456789abcdef0",
+        "KeyType": "ed25519"
+    }
+
+For more information, see `Create a key pair using Amazon EC2 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html>`__ in the *Amazon EC2 User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/create-managed-prefix-list.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/create-managed-prefix-list.rst
@@ -1,4 +1,4 @@
-**To create a prefix list**
+**Example 1: To create an IPv4 prefix list**
 
 The following ``create-managed-prefix-list`` example creates an IPv4 prefix list with a maximum of 10 entries, and creates 2 entries in the prefix list. ::
 
@@ -18,6 +18,34 @@ Output::
             "PrefixListArn": "arn:aws:ec2:us-west-2:123456789012:prefix-list/pl-0123456abcabcabc1",
             "PrefixListName": "vpc-cidrs",
             "MaxEntries": 10,
+            "Version": 1,
+            "Tags": [],
+            "OwnerId": "123456789012"
+        }
+    }
+
+For more information, see `Managed prefix lists <https://docs.aws.amazon.com/vpc/latest/userguide/managed-prefix-lists.html>`__ in the *Amazon VPC User Guide*.
+
+**Example 2: To create an IPv6 prefix list**
+
+The following ``create-managed-prefix-list`` example creates an IPv6 prefix list with a maximum of 5 entries, and creates 2 entries in the prefix list. Note that ``--address-family`` is set to ``IPv6`` and the CIDR entries use IPv6 notation. ::
+
+    aws ec2 create-managed-prefix-list \
+        --address-family IPv6 \
+        --max-entries 5 \
+        --entries Cidr=2001:db8::/32,Description=ipv6-range-a Cidr=2001:db8:1::/48,Description=ipv6-range-b \
+        --prefix-list-name ipv6-cidrs
+
+Output::
+
+    {
+        "PrefixList": {
+            "PrefixListId": "pl-0123456abcabcabc2",
+            "AddressFamily": "IPv6",
+            "State": "create-in-progress",
+            "PrefixListArn": "arn:aws:ec2:us-west-2:123456789012:prefix-list/pl-0123456abcabcabc2",
+            "PrefixListName": "ipv6-cidrs",
+            "MaxEntries": 5,
             "Version": 1,
             "Tags": [],
             "OwnerId": "123456789012"

--- a/emulators/aws-ec2/tests/cli/ec2/create-network-acl-entry.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/create-network-acl-entry.rst
@@ -1,14 +1,100 @@
-**To create a network ACL entry**
+**Example 1: To create an ingress network ACL entry for IPv4 traffic**
 
-This example creates an entry for the specified network ACL. The rule allows ingress traffic from any IPv4 address (0.0.0.0/0) on UDP port 53 (DNS) into any associated subnet. If the command succeeds, no output is returned.
+The following ``create-network-acl-entry`` example creates an ingress rule in the specified network ACL that allows UDP traffic from any IPv4 address on port 53 (DNS). ::
 
-Command::
+    aws ec2 create-network-acl-entry \
+        --network-acl-id acl-5fb85d36 \
+        --ingress \
+        --rule-number 100 \
+        --protocol udp \
+        --port-range From=53,To=53 \
+        --cidr-block 0.0.0.0/0 \
+        --rule-action allow
 
-  aws ec2 create-network-acl-entry --network-acl-id acl-5fb85d36 --ingress --rule-number 100 --protocol udp --port-range From=53,To=53 --cidr-block 0.0.0.0/0 --rule-action allow
+This command produces no output.
 
+For more information, see `Control traffic to subnets using network ACLs <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html>`__ in the *Amazon VPC User Guide*.
 
-This example creates a rule for the specified network ACL that allows ingress traffic from any IPv6 address (::/0) on TCP port 80 (HTTP).
+**Example 2: To create an ingress network ACL entry for IPv6 traffic**
 
-Command::
+The following ``create-network-acl-entry`` example creates an ingress rule that allows TCP traffic from any IPv6 address on port 80 (HTTP). ::
 
-  aws ec2 create-network-acl-entry --network-acl-id acl-5fb85d36 --ingress --rule-number 120 --protocol tcp --port-range From=80,To=80 --ipv6-cidr-block ::/0 --rule-action allow
+    aws ec2 create-network-acl-entry \
+        --network-acl-id acl-5fb85d36 \
+        --ingress \
+        --rule-number 120 \
+        --protocol tcp \
+        --port-range From=80,To=80 \
+        --ipv6-cidr-block ::/0 \
+        --rule-action allow
+
+This command produces no output.
+
+For more information, see `Control traffic to subnets using network ACLs <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html>`__ in the *Amazon VPC User Guide*.
+
+**Example 3: To create an egress network ACL entry for IPv4 traffic**
+
+The following ``create-network-acl-entry`` example creates an egress rule that allows outbound TCP traffic to any IPv4 address on port 443 (HTTPS). ::
+
+    aws ec2 create-network-acl-entry \
+        --network-acl-id acl-5fb85d36 \
+        --egress \
+        --rule-number 100 \
+        --protocol tcp \
+        --port-range From=443,To=443 \
+        --cidr-block 0.0.0.0/0 \
+        --rule-action allow
+
+This command produces no output.
+
+For more information, see `Control traffic to subnets using network ACLs <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html>`__ in the *Amazon VPC User Guide*.
+
+**Example 4: To create an egress network ACL entry for IPv6 traffic**
+
+The following ``create-network-acl-entry`` example creates an egress rule that allows outbound TCP traffic to any IPv6 address on port 443 (HTTPS). ::
+
+    aws ec2 create-network-acl-entry \
+        --network-acl-id acl-5fb85d36 \
+        --egress \
+        --rule-number 120 \
+        --protocol tcp \
+        --port-range From=443,To=443 \
+        --ipv6-cidr-block ::/0 \
+        --rule-action allow
+
+This command produces no output.
+
+For more information, see `Control traffic to subnets using network ACLs <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html>`__ in the *Amazon VPC User Guide*.
+
+**Example 5: To create an ingress deny rule**
+
+The following ``create-network-acl-entry`` example creates an ingress rule that denies all traffic from the specified IPv4 CIDR block. Using a lower rule number (50) gives it higher priority than any allow rules with higher numbers, ensuring the block takes effect first. ::
+
+    aws ec2 create-network-acl-entry \
+        --network-acl-id acl-5fb85d36 \
+        --ingress \
+        --rule-number 50 \
+        --protocol -1 \
+        --cidr-block 203.0.113.0/24 \
+        --rule-action deny
+
+This command produces no output.
+
+For more information, see `Control traffic to subnets using network ACLs <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html>`__ in the *Amazon VPC User Guide*.
+
+**Example 6: To create an egress deny rule**
+
+The following ``create-network-acl-entry`` example creates an egress rule that denies all outbound TCP traffic on port 25 (SMTP) to any IPv4 address, which is commonly used to prevent instances from sending spam. ::
+
+    aws ec2 create-network-acl-entry \
+        --network-acl-id acl-5fb85d36 \
+        --egress \
+        --rule-number 50 \
+        --protocol tcp \
+        --port-range From=25,To=25 \
+        --cidr-block 0.0.0.0/0 \
+        --rule-action deny
+
+This command produces no output.
+
+For more information, see `Control traffic to subnets using network ACLs <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/create-network-acl.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/create-network-acl.rst
@@ -1,35 +1,79 @@
-**To create a network ACL**
+**Example 1: To create a network ACL**
 
-This example creates a network ACL for the specified VPC.
+The following ``create-network-acl`` example creates a network ACL for the specified VPC. AWS automatically adds two default deny-all entries (rule 32767) — one for ingress and one for egress — which cannot be removed. ::
 
-Command::
-
-  aws ec2 create-network-acl --vpc-id vpc-a01106c2
+    aws ec2 create-network-acl \
+        --vpc-id vpc-a01106c2
 
 Output::
 
-  {
-      "NetworkAcl": {
-          "Associations": [],
-          "NetworkAclId": "acl-5fb85d36",
-          "VpcId": "vpc-a01106c2",
-          "Tags": [],
-          "Entries": [
-              {
-                  "CidrBlock": "0.0.0.0/0",
-                  "RuleNumber": 32767,
-                  "Protocol": "-1",
-                  "Egress": true,
-                  "RuleAction": "deny"
-              },
-              {
-                  "CidrBlock": "0.0.0.0/0",
-                  "RuleNumber": 32767,
-                  "Protocol": "-1",
-                  "Egress": false,
-                  "RuleAction": "deny"
-              }
-          ],
-          "IsDefault": false
-      }  
-  }
+    {
+        "NetworkAcl": {
+            "Associations": [],
+            "NetworkAclId": "acl-5fb85d36",
+            "VpcId": "vpc-a01106c2",
+            "Tags": [],
+            "Entries": [
+                {
+                    "CidrBlock": "0.0.0.0/0",
+                    "RuleNumber": 32767,
+                    "Protocol": "-1",
+                    "Egress": true,
+                    "RuleAction": "deny"
+                },
+                {
+                    "CidrBlock": "0.0.0.0/0",
+                    "RuleNumber": 32767,
+                    "Protocol": "-1",
+                    "Egress": false,
+                    "RuleAction": "deny"
+                }
+            ],
+            "IsDefault": false
+        }
+    }
+
+For more information, see `Control traffic to subnets using network ACLs <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html>`__ in the *Amazon VPC User Guide*.
+
+**Example 2: To create a network ACL with a Name tag**
+
+The following ``create-network-acl`` example creates a network ACL and assigns it a name tag at creation time using ``--tag-specifications``. The tag is reflected in the ``Tags`` field of the output. ::
+
+    aws ec2 create-network-acl \
+        --vpc-id vpc-a01106c2 \
+        --tag-specifications ResourceType=network-acl,Tags=[{Key=Name,Value=my-network-acl}]
+
+Output::
+
+    {
+        "NetworkAcl": {
+            "Associations": [],
+            "NetworkAclId": "acl-0e968f94EXAMPLE",
+            "VpcId": "vpc-a01106c2",
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "my-network-acl"
+                }
+            ],
+            "Entries": [
+                {
+                    "CidrBlock": "0.0.0.0/0",
+                    "RuleNumber": 32767,
+                    "Protocol": "-1",
+                    "Egress": true,
+                    "RuleAction": "deny"
+                },
+                {
+                    "CidrBlock": "0.0.0.0/0",
+                    "RuleNumber": 32767,
+                    "Protocol": "-1",
+                    "Egress": false,
+                    "RuleAction": "deny"
+                }
+            ],
+            "IsDefault": false
+        }
+    }
+
+For more information, see `Control traffic to subnets using network ACLs <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/create-route-table.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/create-route-table.rst
@@ -1,26 +1,61 @@
-**To create a route table**
+**Example 1: To create a route table**
 
-This example creates a route table for the specified VPC.
+The following ``create-route-table`` example creates a route table for the specified VPC. ::
 
-Command::
-
-  aws ec2 create-route-table --vpc-id vpc-a01106c2
+    aws ec2 create-route-table \
+        --vpc-id vpc-a01106c2
 
 Output::
 
-  {
-      "RouteTable": {
-          "Associations": [],
-          "RouteTableId": "rtb-22574640",
-          "VpcId": "vpc-a01106c2",
-          "PropagatingVgws": [],
-          "Tags": [],
-          "Routes": [
-              {
-                  "GatewayId": "local",
-                  "DestinationCidrBlock": "10.0.0.0/16",
-                  "State": "active"
-              }
-          ]
-      }  
-  }
+    {
+        "RouteTable": {
+            "Associations": [],
+            "RouteTableId": "rtb-22574640",
+            "VpcId": "vpc-a01106c2",
+            "PropagatingVgws": [],
+            "Tags": [],
+            "Routes": [
+                {
+                    "GatewayId": "local",
+                    "DestinationCidrBlock": "10.0.0.0/16",
+                    "State": "active"
+                }
+            ]
+        }
+    }
+
+For more information, see `Route tables <https://docs.aws.amazon.com/vpc/latest/userguide/WorkWithRouteTables.html>`__ in the *Amazon VPC User Guide*.
+
+**Example 2: To create a route table with a Name tag**
+
+The following ``create-route-table`` example creates a route table and assigns it a name using ``--tag-specifications``. Tagging at creation time avoids a separate ``create-tags`` call. ::
+
+    aws ec2 create-route-table \
+        --vpc-id vpc-a01106c2 \
+        --tag-specifications ResourceType=route-table,Tags=[{Key=Name,Value=my-route-table}]
+
+Output::
+
+    {
+        "RouteTable": {
+            "Associations": [],
+            "RouteTableId": "rtb-22574641",
+            "VpcId": "vpc-a01106c2",
+            "PropagatingVgws": [],
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "my-route-table"
+                }
+            ],
+            "Routes": [
+                {
+                    "GatewayId": "local",
+                    "DestinationCidrBlock": "10.0.0.0/16",
+                    "State": "active"
+                }
+            ]
+        }
+    }
+
+For more information, see `Route tables <https://docs.aws.amazon.com/vpc/latest/userguide/WorkWithRouteTables.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/create-security-group.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/create-security-group.rst
@@ -1,31 +1,60 @@
-**To create a security group for EC2-Classic**
+**Example 1: To create a security group for EC2-Classic**
 
-This example creates a security group named ``MySecurityGroup``.
+The following ``create-security-group`` example creates a security group named ``MySecurityGroup`` for EC2-Classic. Note: EC2-Classic was retired in August 2022 and is no longer available for new accounts. ::
 
-Command::
-
-  aws ec2 create-security-group --group-name MySecurityGroup --description "My security group"
-
-Output::
-
-  {
-      "GroupId": "sg-903004f8"
-  }
-
-**To create a security group for EC2-VPC**
-
-This example creates a security group named ``MySecurityGroup`` for the specified VPC.
-
-Command::
-
-  aws ec2 create-security-group --group-name MySecurityGroup --description "My security group" --vpc-id vpc-1a2b3c4d
+    aws ec2 create-security-group \
+        --group-name MySecurityGroup \
+        --description "My security group"
 
 Output::
 
-  {
-      "GroupId": "sg-903004f8"
-  }
+    {
+        "GroupId": "sg-903004f8"
+    }
 
-For more information, see `Using Security Groups`_ in the *AWS Command Line Interface User Guide*.
+For more information, see `Amazon EC2 security groups <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html>`__ in the *Amazon EC2 User Guide*.
 
-.. _`Using Security Groups`: http://docs.aws.amazon.com/cli/latest/userguide/cli-ec2-sg.html
+**Example 2: To create a security group for a VPC**
+
+The following ``create-security-group`` example creates a security group named ``MySecurityGroup`` for the specified VPC. ::
+
+    aws ec2 create-security-group \
+        --group-name MySecurityGroup \
+        --description "My security group" \
+        --vpc-id vpc-1a2b3c4d
+
+Output::
+
+    {
+        "GroupId": "sg-903004f8"
+    }
+
+For more information, see `Amazon EC2 security groups <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html>`__ in the *Amazon EC2 User Guide*.
+
+**Example 3: To create a security group with tags**
+
+The following ``create-security-group`` example creates a security group in the specified VPC and assigns it a name and environment tag using ``--tag-specifications``. The tags are reflected in the output. ::
+
+    aws ec2 create-security-group \
+        --group-name MySecurityGroup \
+        --description "My security group" \
+        --vpc-id vpc-1a2b3c4d \
+        --tag-specifications ResourceType=security-group,Tags=[{Key=Name,Value=my-sg},{Key=Environment,Value=production}]
+
+Output::
+
+    {
+        "GroupId": "sg-1234567890abcdef0",
+        "Tags": [
+            {
+                "Key": "Name",
+                "Value": "my-sg"
+            },
+            {
+                "Key": "Environment",
+                "Value": "production"
+            }
+        ]
+    }
+
+For more information, see `Amazon EC2 security groups <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html>`__ in the *Amazon EC2 User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/create-transit-gateway-route-table.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/create-transit-gateway-route-table.rst
@@ -1,4 +1,4 @@
-**To create a Transit Gateway Route Table**
+**Example 1: To create a transit gateway route table**
 
 The following ``create-transit-gateway-route-table`` example creates a route table for the specified transit gateway. ::
 
@@ -14,7 +14,37 @@ Output::
             "State": "pending",
             "DefaultAssociationRouteTable": false,
             "DefaultPropagationRouteTable": false,
-            "CreationTime": "2019-07-10T19:01:46.000Z"
+            "CreationTime": "2019-07-10T19:01:46.000Z",
+            "Tags": []
+        }
+    }
+
+For more information, see `Create a transit gateway route table <https://docs.aws.amazon.com/vpc/latest/tgw/tgw-route-tables.html#create-tgw-route-table>`__ in the *Transit Gateways Guide*.
+
+**Example 2: To create a transit gateway route table with a Name tag**
+
+The following ``create-transit-gateway-route-table`` example creates a route table for the specified transit gateway and assigns it a name tag at creation time using ``--tag-specifications``. ::
+
+    aws ec2 create-transit-gateway-route-table \
+        --transit-gateway-id tgw-0262a0e521EXAMPLE \
+        --tag-specifications ResourceType=transit-gateway-route-table,Tags=[{Key=Name,Value=my-tgw-route-table}]
+
+Output::
+
+    {
+        "TransitGatewayRouteTable": {
+            "TransitGatewayRouteTableId": "tgw-rtb-0a5d75EXAMPLE",
+            "TransitGatewayId": "tgw-0262a0e521EXAMPLE",
+            "State": "pending",
+            "DefaultAssociationRouteTable": false,
+            "DefaultPropagationRouteTable": false,
+            "CreationTime": "2019-07-10T19:01:46.000Z",
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "my-tgw-route-table"
+                }
+            ]
         }
     }
 

--- a/emulators/aws-ec2/tests/cli/ec2/delete-customer-gateway.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-customer-gateway.rst
@@ -1,7 +1,10 @@
 **To delete a customer gateway**
 
-This example deletes the specified customer gateway. If the command succeeds, no output is returned.
+The following ``delete-customer-gateway`` example deletes the specified customer gateway. ::
 
-Command::
+    aws ec2 delete-customer-gateway \
+        --customer-gateway-id cgw-0e11f167
 
-  aws ec2 delete-customer-gateway --customer-gateway-id cgw-0e11f167
+This command produces no output.
+
+For more information, see `Customer gateways <https://docs.aws.amazon.com/vpn/latest/s2svpn/your-cgw.html>`__ in the *AWS Site-to-Site VPN User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/delete-dhcp-options.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-dhcp-options.rst
@@ -1,7 +1,10 @@
 **To delete a DHCP options set**
 
-This example deletes the specified DHCP options set. If the command succeeds, no output is returned.
+The following ``delete-dhcp-options`` example deletes the specified DHCP options set. ::
 
-Command::
+    aws ec2 delete-dhcp-options \
+        --dhcp-options-id dopt-d9070ebb
 
-  aws ec2 delete-dhcp-options --dhcp-options-id dopt-d9070ebb
+This command produces no output.
+
+For more information, see `DHCP option sets <https://docs.aws.amazon.com/vpc/latest/userguide/VPC_DHCP_Options.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/delete-network-acl-entry.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-network-acl-entry.rst
@@ -1,7 +1,12 @@
 **To delete a network ACL entry**
 
-This example deletes ingress rule number 100 from the specified network ACL. If the command succeeds, no output is returned.
+The following ``delete-network-acl-entry`` example deletes ingress rule number 100 from the specified network ACL. ::
 
-Command::
+    aws ec2 delete-network-acl-entry \
+        --network-acl-id acl-5fb85d36 \
+        --ingress \
+        --rule-number 100
 
-  aws ec2 delete-network-acl-entry --network-acl-id acl-5fb85d36 --ingress --rule-number 100
+This command produces no output.
+
+For more information, see `Control traffic to subnets using network ACLs <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/delete-network-acl.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-network-acl.rst
@@ -1,7 +1,10 @@
 **To delete a network ACL**
 
-This example deletes the specified network ACL. If the command succeeds, no output is returned.
+The following ``delete-network-acl`` example deletes the specified network ACL. ::
 
-Command::
+    aws ec2 delete-network-acl \
+        --network-acl-id acl-5fb85d36
 
-  aws ec2 delete-network-acl --network-acl-id acl-5fb85d36
+This command produces no output.
+
+For more information, see `Control traffic to subnets using network ACLs <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/delete-network-interface.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-network-interface.rst
@@ -1,7 +1,10 @@
 **To delete a network interface**
 
-This example deletes the specified network interface. If the command succeeds, no output is returned.
+The following ``delete-network-interface`` example deletes the specified network interface. ::
 
-Command::
+    aws ec2 delete-network-interface \
+        --network-interface-id eni-e5aa89a3
 
-  aws ec2 delete-network-interface --network-interface-id eni-e5aa89a3
+This command produces no output.
+
+For more information, see `Elastic network interfaces <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html>`__ in the *Amazon EC2 User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/delete-placement-group.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-placement-group.rst
@@ -1,7 +1,10 @@
 **To delete a placement group**
 
-This example command deletes the specified placement group.
+The following ``delete-placement-group`` example deletes the specified placement group. ::
 
-Command::
+    aws ec2 delete-placement-group \
+        --group-name my-cluster
 
-  aws ec2 delete-placement-group --group-name my-cluster
+This command produces no output.
+
+For more information, see `Placement groups <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html>`__ in the *Amazon EC2 User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/delete-route-table.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-route-table.rst
@@ -1,7 +1,10 @@
 **To delete a route table**
 
-This example deletes the specified route table. If the command succeeds, no output is returned.
+The following ``delete-route-table`` example deletes the specified route table. ::
 
-Command::
+    aws ec2 delete-route-table \
+        --route-table-id rtb-22574640
 
-  aws ec2 delete-route-table --route-table-id rtb-22574640
+This command produces no output.
+
+For more information, see `Route tables <https://docs.aws.amazon.com/vpc/latest/userguide/WorkWithRouteTables.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/delete-route.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-route.rst
@@ -1,7 +1,11 @@
 **To delete a route**
 
-This example deletes the specified route from the specified route table. If the command succeeds, no output is returned.
+The following ``delete-route`` example deletes the specified route from the specified route table. ::
 
-Command::
+    aws ec2 delete-route \
+        --route-table-id rtb-22574640 \
+        --destination-cidr-block 0.0.0.0/0
 
-  aws ec2 delete-route --route-table-id rtb-22574640 --destination-cidr-block 0.0.0.0/0
+This command produces no output.
+
+For more information, see `Route tables <https://docs.aws.amazon.com/vpc/latest/userguide/WorkWithRouteTables.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/delete-snapshot.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-snapshot.rst
@@ -1,7 +1,10 @@
 **To delete a snapshot**
 
-This example command deletes a snapshot with the snapshot ID of ``snap-1234567890abcdef0``. If the command succeeds, no output is returned.
+The following ``delete-snapshot`` example deletes the specified snapshot. ::
 
-Command::
+    aws ec2 delete-snapshot \
+        --snapshot-id snap-1234567890abcdef0
 
-  aws ec2 delete-snapshot --snapshot-id snap-1234567890abcdef0
+This command produces no output.
+
+For more information, see `Delete an Amazon EBS snapshot <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-deleting-snapshot.html>`__ in the *Amazon EC2 User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/delete-subnet.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-subnet.rst
@@ -1,7 +1,10 @@
 **To delete a subnet**
 
-This example deletes the specified subnet. If the command succeeds, no output is returned.
+The following ``delete-subnet`` example deletes the specified subnet. ::
 
-Command::
+    aws ec2 delete-subnet \
+        --subnet-id subnet-9d4a7b6c
 
-  aws ec2 delete-subnet --subnet-id subnet-9d4a7b6c
+This command produces no output.
+
+For more information, see `Subnets <https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/delete-vpc.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/delete-vpc.rst
@@ -1,7 +1,10 @@
 **To delete a VPC**
 
-This example deletes the specified VPC. If the command succeeds, no output is returned.
+The following ``delete-vpc`` example deletes the specified VPC. ::
 
-Command::
+    aws ec2 delete-vpc \
+        --vpc-id vpc-a01106c2
 
-  aws ec2 delete-vpc --vpc-id vpc-a01106c2
+This command produces no output.
+
+For more information, see `Work with VPCs <https://docs.aws.amazon.com/vpc/latest/userguide/working-with-vpcs.html>`__ in the *Amazon VPC User Guide*.

--- a/emulators/aws-ec2/tests/cli/ec2/start-instances.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/start-instances.rst
@@ -1,10 +1,9 @@
 **To start an Amazon EC2 instance**
 
-This example starts the specified Amazon EBS-backed instance.
+The following ``start-instances`` example starts the specified Amazon EBS-backed instance. ::
 
-Command::
-
-  aws ec2 start-instances --instance-ids i-1234567890abcdef0
+    aws ec2 start-instances \
+        --instance-ids i-1234567890abcdef0
 
 Output::
 
@@ -24,7 +23,4 @@ Output::
         ]
     }
 
-For more information, see `Stop and Start Your Instance`_ in the *Amazon Elastic Compute Cloud User Guide*.
-
-.. _`Stop and Start Your Instance`: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Stop_Start.html
-
+For more information, see `Stop and Start Your Instance <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Stop_Start.html>`__ in the *Amazon Elastic Compute Cloud User Guide*.


### PR DESCRIPTION
11 delete service test cases, reformatted command:: to multi-line command to emphasize on passed arguments (consistent with some newly updated test cases)

Create-key-pair.rst: formatting, added second test case for ED25519 keys, a different algorithm

Create-route-table.rst: formatting, added second test case that uses –tag-specifications at creation to avoid separate create-tags call later

Create-security-group.rst: formatting, ec2-classic way of creating a security group without the a VPC id is retired in 2022 (any amazon accounts created after 2013~), added that as a note, could delete later, added example 3 that adds on to example 2 with name and environment tags assigned at creation. 

Create-internet-gateway.rst: formatting, added base case of creating internet getway without a tag.

Create-network-acl-entry.rst: formatting, added 4 more test cases: Egress IPv4, Egress IPv6, Ingress –rule action deny instead of allow, Egress deny rule.

Create-managed-prefix-list.rst: formatting, added test case for IPv6, with argument differences explained in command description

Create-network-acl.rst: formatting, added test case for creating with a name tag

Create-egress-only-gateway.rst: formatting and added test case with name tag argument in creation command

Create-transit-gateway-route-table.rst: formatting, added test case with name tag 
