### PR TITLE
test: add aws-ec2 tests

### DIFF
--- a/emulators/aws-ec2/tests/cli/ec2/ebs-encryption-lifecycle.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/ebs-encryption-lifecycle.rst
@@ -1,0 +1,59 @@
+**Example 1: To check EBS encryption status before making changes**
+
+The following ``get-ebs-encryption-by-default`` example checks whether EBS encryption by default is enabled. ::
+
+    aws ec2 get-ebs-encryption-by-default
+
+Output::
+
+    {
+        "EbsEncryptionByDefault": false
+    }
+
+**Example 2: To enable EBS encryption by default**
+
+The following ``enable-ebs-encryption-by-default`` example enables EBS encryption by default for your AWS account in the current Region. ::
+
+    aws ec2 enable-ebs-encryption-by-default
+
+Output::
+
+    {
+        "EbsEncryptionByDefault": true
+    }
+
+**Example 3: To verify EBS encryption is enabled**
+
+The following ``get-ebs-encryption-by-default`` example verifies that EBS encryption by default is now enabled. ::
+
+    aws ec2 get-ebs-encryption-by-default
+
+Output::
+
+    {
+        "EbsEncryptionByDefault": true
+    }
+
+**Example 4: To disable EBS encryption by default**
+
+The following ``disable-ebs-encryption-by-default`` example disables EBS encryption by default for your AWS account in the current Region. ::
+
+    aws ec2 disable-ebs-encryption-by-default
+
+Output::
+
+    {
+        "EbsEncryptionByDefault": false
+    }
+
+**Example 5: To verify EBS encryption is disabled**
+
+The following ``get-ebs-encryption-by-default`` example verifies that EBS encryption by default is now disabled. ::
+
+    aws ec2 get-ebs-encryption-by-default
+
+Output::
+
+    {
+        "EbsEncryptionByDefault": false
+    }

--- a/emulators/aws-ec2/tests/cli/ec2/ebs-volume-lifecycle.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/ebs-volume-lifecycle.rst
@@ -1,0 +1,281 @@
+**Example 1: To launch an instance**
+
+The following ``run-instances`` example launches a ``t2.micro`` instance that will be used to attach an EBS volume. ::
+
+    aws ec2 run-instances \
+        --image-id ami-xxxxxxxx \
+        --count 1 \
+        --instance-type t2.micro \
+        --key-name MyKeyPair \
+        --security-group-ids sg-903004f8 \
+        --subnet-id subnet-6e7f829e
+
+Output::
+
+    {
+        "Instances": [
+            {
+                "AmiLaunchIndex": 0,
+                "ImageId": "ami-xxxxxxxx",
+                "InstanceId": "i-5203422c",
+                "InstanceType": "t2.micro",
+                "KeyName": "MyKeyPair",
+                "LaunchTime": "YYYY-MM-DDTHH:MM:SS.000Z",
+                "Monitoring": {
+                    "State": "disabled"
+                },
+                "Placement": {
+                    "AvailabilityZone": "us-east-1a",
+                    "GroupName": "",
+                    "Tenancy": "default"
+                },
+                "PrivateDnsName": "ip-10-0-0-157.us-east-1.compute.internal",
+                "PrivateIpAddress": "10.0.0.157",
+                "ProductCodes": [],
+                "PublicDnsName": "",
+                "State": {
+                    "Code": 0,
+                    "Name": "pending"
+                },
+                "StateTransitionReason": "",
+                "SubnetId": "subnet-6e7f829e",
+                "VpcId": "vpc-1a2b3c4d",
+                "Architecture": "x86_64",
+                "BlockDeviceMappings": [],
+                "ClientToken": "",
+                "EbsOptimized": false,
+                "Hypervisor": "xen",
+                "NetworkInterfaces": [
+                    {
+                        "Attachment": {
+                            "AttachTime": "YYYY-MM-DDTHH:MM:SS.000Z",
+                            "AttachmentId": "eni-attach-0e325c07e928a0405",
+                            "DeleteOnTermination": true,
+                            "DeviceIndex": 0,
+                            "Status": "attaching"
+                        },
+                        "Description": "",
+                        "Groups": [
+                            {
+                                "GroupName": "MySecurityGroup",
+                                "GroupId": "sg-903004f8"
+                            }
+                        ],
+                        "Ipv6Addresses": [],
+                        "MacAddress": "0a:ab:58:e0:67:e2",
+                        "NetworkInterfaceId": "eni-0c0a29997760baee7",
+                        "OwnerId": "123456789012",
+                        "PrivateDnsName": "ip-10-0-0-157.us-east-1.compute.internal",
+                        "PrivateIpAddress": "10.0.0.157",
+                        "PrivateIpAddresses": [
+                            {
+                                "Primary": true,
+                                "PrivateDnsName": "ip-10-0-0-157.us-east-1.compute.internal",
+                                "PrivateIpAddress": "10.0.0.157"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Status": "in-use",
+                        "SubnetId": "subnet-6e7f829e",
+                        "VpcId": "vpc-1a2b3c4d",
+                        "InterfaceType": "interface"
+                    }
+                ],
+                "RootDeviceName": "/dev/xvda",
+                "RootDeviceType": "ebs",
+                "SecurityGroups": [
+                    {
+                        "GroupName": "MySecurityGroup",
+                        "GroupId": "sg-903004f8"
+                    }
+                ],
+                "SourceDestCheck": true,
+                "StateReason": {
+                    "Code": "pending",
+                    "Message": "pending"
+                },
+                "Tags": [],
+                "VirtualizationType": "hvm",
+                "CpuOptions": {
+                    "CoreCount": 1,
+                    "ThreadsPerCore": 1
+                },
+                "CapacityReservationSpecification": {
+                    "CapacityReservationPreference": "open"
+                },
+                "MetadataOptions": {
+                    "State": "pending",
+                    "HttpTokens": "optional",
+                    "HttpPutResponseHopLimit": 1,
+                    "HttpEndpoint": "enabled"
+                }
+            }
+        ],
+        "OwnerId": "123456789012",
+        "ReservationId": "r-5875ca20"
+    }
+
+**Example 2: To wait until the instance is running**
+
+The following ``wait instance-running`` example pauses until the instance is running. It produces no output. ::
+
+    aws ec2 wait instance-running \
+        --instance-ids i-5203422c
+
+**Example 3: To create an EBS volume**
+
+The following ``create-volume`` example creates a 20 GiB General Purpose SSD (gp2) volume in the specified Availability Zone. ::
+
+    aws ec2 create-volume \
+        --volume-type gp2 \
+        --size 20 \
+        --availability-zone us-east-1a \
+        --tag-specifications ResourceType=volume,Tags=[{Key=Name,Value=MyDataVolume}]
+
+Output::
+
+    {
+        "AvailabilityZone": "us-east-1a",
+        "Tags": [
+            {
+                "Key": "Name",
+                "Value": "MyDataVolume"
+            }
+        ],
+        "Encrypted": false,
+        "VolumeType": "gp2",
+        "VolumeId": "vol-1234567890abcdef0",
+        "State": "creating",
+        "Iops": 100,
+        "SnapshotId": "",
+        "CreateTime": "YYYY-MM-DDTHH:MM:SS.000Z",
+        "Size": 20
+    }
+
+**Example 4: To wait until the volume is available**
+
+The following ``wait volume-available`` example pauses until the volume is available for attachment. It produces no output. ::
+
+    aws ec2 wait volume-available \
+        --volume-ids vol-1234567890abcdef0
+
+**Example 5: To attach the volume to the instance**
+
+The following ``attach-volume`` example attaches the volume to the instance as ``/dev/sdf``. ::
+
+    aws ec2 attach-volume \
+        --volume-id vol-1234567890abcdef0 \
+        --instance-id i-5203422c \
+        --device /dev/sdf
+
+Output::
+
+    {
+        "AttachTime": "YYYY-MM-DDTHH:MM:SS.000Z",
+        "InstanceId": "i-5203422c",
+        "VolumeId": "vol-1234567890abcdef0",
+        "State": "attaching",
+        "Device": "/dev/sdf"
+    }
+
+**Example 6: To verify the volume is attached**
+
+The following ``describe-volumes`` example queries the volume to verify it is in the ``in-use`` state and attached to the instance. ::
+
+    aws ec2 describe-volumes \
+        --volume-ids vol-1234567890abcdef0 \
+        --query "Volumes[0].{State:State,InstanceId:Attachments[0].InstanceId,Device:Attachments[0].Device}"
+
+Output::
+
+    {
+        "State": "in-use",
+        "InstanceId": "i-5203422c",
+        "Device": "/dev/sdf"
+    }
+
+**Example 7: To create a snapshot of the volume**
+
+The following ``create-snapshot`` example creates a snapshot of the attached volume with a description. ::
+
+    aws ec2 create-snapshot \
+        --volume-id vol-1234567890abcdef0 \
+        --description "Snapshot of MyDataVolume"
+
+Output::
+
+    {
+        "Description": "Snapshot of MyDataVolume",
+        "Tags": [],
+        "Encrypted": false,
+        "VolumeId": "vol-1234567890abcdef0",
+        "State": "pending",
+        "VolumeSize": 20,
+        "StartTime": "YYYY-MM-DDTHH:MM:SS.000Z",
+        "Progress": "",
+        "OwnerId": "123456789012",
+        "SnapshotId": "snap-066877671789bd71b"
+    }
+
+**Example 8: To wait until the snapshot is completed**
+
+The following ``wait snapshot-completed`` example pauses until the snapshot finishes. It produces no output. ::
+
+    aws ec2 wait snapshot-completed \
+        --snapshot-ids snap-066877671789bd71b
+
+**Example 9: To detach the volume from the instance**
+
+The following ``detach-volume`` example detaches the volume from the instance. ::
+
+    aws ec2 detach-volume \
+        --volume-id vol-1234567890abcdef0
+
+Output::
+
+    {
+        "AttachTime": "YYYY-MM-DDTHH:MM:SS.000Z",
+        "InstanceId": "i-5203422c",
+        "VolumeId": "vol-1234567890abcdef0",
+        "State": "detaching",
+        "Device": "/dev/sdf"
+    }
+
+**Example 10: To wait until the volume is available again**
+
+The following ``wait volume-available`` example pauses until the volume is fully detached and available. It produces no output. ::
+
+    aws ec2 wait volume-available \
+        --volume-ids vol-1234567890abcdef0
+
+**Example 11: To delete the volume**
+
+The following ``delete-volume`` example deletes the volume. If the command succeeds, no output is returned. ::
+
+    aws ec2 delete-volume \
+        --volume-id vol-1234567890abcdef0
+
+**Example 12: To terminate the instance**
+
+The following ``terminate-instances`` example terminates the instance used in this workflow. ::
+
+    aws ec2 terminate-instances \
+        --instance-ids i-5203422c
+
+Output::
+
+    {
+        "TerminatingInstances": [
+            {
+                "InstanceId": "i-5203422c",
+                "CurrentState": {
+                    "Code": 32,
+                    "Name": "shutting-down"
+                },
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ]
+    }

--- a/emulators/aws-ec2/tests/cli/ec2/filter-instances-found.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/filter-instances-found.rst
@@ -1,0 +1,165 @@
+**Example 1: To launch the first instance**
+
+The following ``run-instances`` example launches a ``t2.micro`` instance tagged ``MyInstance``. ::
+
+    aws ec2 run-instances \
+        --image-id ami-xxxxxxxx \
+        --count 1 \
+        --instance-type t2.micro \
+        --key-name MyKeyPair \
+        --security-group-ids sg-903004f8 \
+        --subnet-id subnet-6e7f829e
+
+Output::
+
+    {
+        "OwnerId": "123456789012",
+        "ReservationId": "r-5875ca20",
+        "Instances": [
+            {
+                "InstanceId": "i-5203422c",
+                "InstanceType": "t2.micro",
+                "State": {
+                    "Code": 0,
+                    "Name": "pending"
+                },
+                "VpcId": "vpc-1a2b3c4d",
+                "SubnetId": "subnet-6e7f829e"
+            }
+        ]
+    }
+
+**Example 2: To wait until the first instance is running**
+
+The following ``wait instance-running`` example pauses until the first instance is running. It produces no output. ::
+
+    aws ec2 wait instance-running \
+        --instance-ids i-5203422c
+
+**Example 3: To tag the first instance**
+
+The following ``create-tags`` example tags the first instance with ``Name=MyInstance``. ::
+
+    aws ec2 create-tags \
+        --resources i-5203422c \
+        --tags Key=Name,Value=MyInstance
+
+**Example 4: To launch the second instance**
+
+The following ``run-instances`` example launches a second ``t2.micro`` instance tagged ``OtherInstance``. ::
+
+    aws ec2 run-instances \
+        --image-id ami-xxxxxxxx \
+        --count 1 \
+        --instance-type t2.micro \
+        --key-name MyKeyPair \
+        --security-group-ids sg-903004f8 \
+        --subnet-id subnet-6e7f829e
+
+Output::
+
+    {
+        "OwnerId": "123456789012",
+        "ReservationId": "r-6934db31",
+        "Instances": [
+            {
+                "InstanceId": "i-6304533d",
+                "InstanceType": "t2.micro",
+                "State": {
+                    "Code": 0,
+                    "Name": "pending"
+                },
+                "VpcId": "vpc-1a2b3c4d",
+                "SubnetId": "subnet-6e7f829e"
+            }
+        ]
+    }
+
+**Example 5: To wait until the second instance is running**
+
+The following ``wait instance-running`` example pauses until the second instance is running. It produces no output. ::
+
+    aws ec2 wait instance-running \
+        --instance-ids i-6304533d
+
+**Example 6: To tag the second instance**
+
+The following ``create-tags`` example tags the second instance with ``Name=OtherInstance``. ::
+
+    aws ec2 create-tags \
+        --resources i-6304533d \
+        --tags Key=Name,Value=OtherInstance
+
+**Example 7: To filter instances by tag and find a match**
+
+The following ``describe-instances`` example filters by ``Name=MyInstance`` and returns only the matching instance. ::
+
+    aws ec2 describe-instances \
+        --filters "Name=tag:Name,Values=MyInstance"
+
+Output::
+
+    {
+        "Reservations": [
+            {
+                "OwnerId": "123456789012",
+                "ReservationId": "r-5875ca20",
+                "Instances": [
+                    {
+                        "InstanceId": "i-5203422c",
+                        "InstanceType": "t2.micro",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "Tags": [
+                            {
+                                "Key": "Name",
+                                "Value": "MyInstance"
+                            }
+                        ],
+                        "VpcId": "vpc-1a2b3c4d",
+                        "SubnetId": "subnet-6e7f829e"
+                    }
+                ]
+            }
+        ]
+    }
+
+**Example 8: To terminate the instances**
+
+The following ``terminate-instances`` example terminates both instances. ::
+
+    aws ec2 terminate-instances \
+        --instance-ids i-5203422c i-6304533d
+
+Output::
+
+    {
+        "TerminatingInstances": [
+            {
+                "InstanceId": "i-5203422c",
+                "CurrentState": {
+                    "Code": 32,
+                    "Name": "shutting-down"
+                },
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            },
+            {
+                "InstanceId": "i-6304533d",
+                "CurrentState": {
+                    "Code": 32,
+                    "Name": "shutting-down"
+                },
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ]
+    }
+
+For more information, see `Launching, listing, and deleting Amazon EC2 instances in the AWS CLI <https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-instances.html>`

--- a/emulators/aws-ec2/tests/cli/ec2/filter-instances-not-found.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/filter-instances-not-found.rst
@@ -1,0 +1,85 @@
+**Example 1: To launch an instance**
+
+The following ``run-instances`` example launches a ``t2.micro`` instance. ::
+
+    aws ec2 run-instances \
+        --image-id ami-xxxxxxxx \
+        --count 1 \
+        --instance-type t2.micro \
+        --key-name MyKeyPair \
+        --security-group-ids sg-903004f8 \
+        --subnet-id subnet-6e7f829e
+
+Output::
+
+    {
+        "OwnerId": "123456789012",
+        "ReservationId": "r-5875ca20",
+        "Instances": [
+            {
+                "InstanceId": "i-5203422c",
+                "InstanceType": "t2.micro",
+                "State": {
+                    "Code": 0,
+                    "Name": "pending"
+                },
+                "VpcId": "vpc-1a2b3c4d",
+                "SubnetId": "subnet-6e7f829e"
+            }
+        ]
+    }
+
+**Example 2: To wait until the instance is running**
+
+The following ``wait instance-running`` example pauses until the instance is running. It produces no output. ::
+
+    aws ec2 wait instance-running \
+        --instance-ids i-5203422c
+
+**Example 3: To tag the instance**
+
+The following ``create-tags`` example tags the instance with ``Name=MyInstance``. ::
+
+    aws ec2 create-tags \
+        --resources i-5203422c \
+        --tags Key=Name,Value=MyInstance
+
+**Example 4: To filter instances by tag and find no match**
+
+The following ``describe-instances`` example filters by a tag that does not match any existing instance, returning an empty result. ::
+
+    aws ec2 describe-instances \
+        --filters "Name=tag:Name,Values=NonExistentInstance"
+
+Output::
+
+    {
+        "Reservations": []
+    }
+
+**Example 5: To terminate the instance**
+
+The following ``terminate-instances`` example terminates the instance. ::
+
+    aws ec2 terminate-instances \
+        --instance-ids i-5203422c
+
+Output::
+
+    {
+        "TerminatingInstances": [
+            {
+                "InstanceId": "i-5203422c",
+                "CurrentState": {
+                    "Code": 32,
+                    "Name": "shutting-down"
+                },
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ]
+    }
+
+For more information, see `Launching, listing, and deleting Amazon EC2 instances in the AWS CLI <https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-instances.html>`

--- a/emulators/aws-ec2/tests/cli/ec2/filter-instances-query.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/filter-instances-query.rst
@@ -1,0 +1,118 @@
+**Example 1: To launch an instance**
+
+The following ``run-instances`` example launches a ``t2.micro`` instance. ::
+
+    aws ec2 run-instances \
+        --image-id ami-xxxxxxxx \
+        --count 1 \
+        --instance-type t2.micro \
+        --key-name MyKeyPair \
+        --security-group-ids sg-903004f8 \
+        --subnet-id subnet-6e7f829e
+
+Output::
+
+    {
+        "OwnerId": "123456789012",
+        "ReservationId": "r-5875ca20",
+        "Instances": [
+            {
+                "InstanceId": "i-5203422c",
+                "InstanceType": "t2.micro",
+                "State": {
+                    "Code": 0,
+                    "Name": "pending"
+                },
+                "VpcId": "vpc-1a2b3c4d",
+                "SubnetId": "subnet-6e7f829e"
+            }
+        ]
+    }
+
+**Example 2: To wait until the instance is running**
+
+The following ``wait instance-running`` example pauses until the instance is running. It produces no output. ::
+
+    aws ec2 wait instance-running \
+        --instance-ids i-5203422c
+
+**Example 3: To query the instance ID**
+
+The following ``describe-instances`` example filters by instance type and returns only the instance ID. ::
+
+    aws ec2 describe-instances \
+        --filters "Name=instance-type,Values=t2.micro" \
+        --query "Reservations[].Instances[].InstanceId"
+
+Output::
+
+    [
+        "i-5203422c"
+    ]
+
+**Example 4: To query the current state of the instance**
+
+The following ``describe-instances`` example filters by instance type and returns only the current state of the instance. ::
+
+    aws ec2 describe-instances \
+        --filters "Name=instance-type,Values=t2.micro" \
+        --query "Reservations[].Instances[].State"
+
+Output::
+
+    [
+        {
+            "Code": 16,
+            "Name": "running"
+        }
+    ]
+
+**Example 5: To query the instance ID and current state together**
+
+The following ``describe-instances`` example filters by instance type and returns the instance ID alongside its current state. ::
+
+    aws ec2 describe-instances \
+        --filters "Name=instance-type,Values=t2.micro" \
+        --query "Reservations[].Instances[].{InstanceId:InstanceId,State:State.Name}"
+
+Output::
+
+    [
+        {
+            "InstanceId": "i-5203422c",
+            "State": "running"
+        }
+    ]
+
+**Example 6: To terminate the instance**
+
+The following ``terminate-instances`` example terminates the instance. ::
+
+    aws ec2 terminate-instances \
+        --instance-ids i-5203422c
+
+Output::
+
+    {
+        "TerminatingInstances": [
+            {
+                "InstanceId": "i-5203422c",
+                "CurrentState": {
+                    "Code": 32,
+                    "Name": "shutting-down"
+                },
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ]
+    }
+
+**Example 7: To wait until the instance is terminated**
+
+The following ``wait instance-terminated`` example pauses until the instance is terminated. It produces no output. ::
+
+    aws ec2 wait instance-terminated \
+        --instance-ids i-5203422c
+

--- a/emulators/aws-ec2/tests/cli/ec2/key-pair-instance-lifecycle.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/key-pair-instance-lifecycle.rst
@@ -1,0 +1,241 @@
+**Example 1: To create a key pair**
+
+The following ``create-key-pair`` example creates a key pair named ``MyKeyPair`` and saves the private key to a local PEM file. ::
+
+    aws ec2 create-key-pair \
+        --key-name MyKeyPair \
+        --query "KeyMaterial" \
+        --output text > MyKeyPair.pem
+
+**Example 2: To verify the key pair was created**
+
+The following ``describe-key-pairs`` example describes the newly created key pair to verify it exists. ::
+
+    aws ec2 describe-key-pairs \
+        --key-names MyKeyPair
+
+Output::
+
+    {
+        "KeyPairs": [
+            {
+                "KeyPairId": "key-0b94643da6EXAMPLE",
+                "KeyFingerprint": "1f:51:ae:28:bf:89:e9:d8:1f:25:5d:37:2d:7d:b8:ca:9f:f5:f1:6f",
+                "KeyName": "MyKeyPair",
+                "KeyType": "rsa",
+                "Tags": [],
+                "CreateTime": "YYYY-MM-DDTHH:MM:SS.000Z"
+            }
+        ]
+    }
+
+**Example 3: To launch an instance with the key pair**
+
+The following ``run-instances`` example launches a ``t2.micro`` instance using the newly created key pair. ::
+
+    aws ec2 run-instances \
+        --image-id ami-xxxxxxxx \
+        --count 1 \
+        --instance-type t2.micro \
+        --key-name MyKeyPair \
+        --security-group-ids sg-903004f8 \
+        --subnet-id subnet-6e7f829e
+
+Output::
+
+    {
+        "Instances": [
+            {
+                "AmiLaunchIndex": 0,
+                "ImageId": "ami-xxxxxxxx",
+                "InstanceId": "i-5203422c",
+                "InstanceType": "t2.micro",
+                "KeyName": "MyKeyPair",
+                "LaunchTime": "YYYY-MM-DDTHH:MM:SS.000Z",
+                "Monitoring": {
+                    "State": "disabled"
+                },
+                "Placement": {
+                    "AvailabilityZone": "us-east-1a",
+                    "GroupName": "",
+                    "Tenancy": "default"
+                },
+                "PrivateDnsName": "ip-10-0-0-157.us-east-1.compute.internal",
+                "PrivateIpAddress": "10.0.0.157",
+                "ProductCodes": [],
+                "PublicDnsName": "",
+                "State": {
+                    "Code": 0,
+                    "Name": "pending"
+                },
+                "StateTransitionReason": "",
+                "SubnetId": "subnet-6e7f829e",
+                "VpcId": "vpc-1a2b3c4d",
+                "Architecture": "x86_64",
+                "BlockDeviceMappings": [],
+                "ClientToken": "",
+                "EbsOptimized": false,
+                "Hypervisor": "xen",
+                "NetworkInterfaces": [
+                    {
+                        "Attachment": {
+                            "AttachTime": "YYYY-MM-DDTHH:MM:SS.000Z",
+                            "AttachmentId": "eni-attach-0e325c07e928a0405",
+                            "DeleteOnTermination": true,
+                            "DeviceIndex": 0,
+                            "Status": "attaching"
+                        },
+                        "Description": "",
+                        "Groups": [
+                            {
+                                "GroupName": "MySecurityGroup",
+                                "GroupId": "sg-903004f8"
+                            }
+                        ],
+                        "Ipv6Addresses": [],
+                        "MacAddress": "0a:ab:58:e0:67:e2",
+                        "NetworkInterfaceId": "eni-0c0a29997760baee7",
+                        "OwnerId": "123456789012",
+                        "PrivateDnsName": "ip-10-0-0-157.us-east-1.compute.internal",
+                        "PrivateIpAddress": "10.0.0.157",
+                        "PrivateIpAddresses": [
+                            {
+                                "Primary": true,
+                                "PrivateDnsName": "ip-10-0-0-157.us-east-1.compute.internal",
+                                "PrivateIpAddress": "10.0.0.157"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Status": "in-use",
+                        "SubnetId": "subnet-6e7f829e",
+                        "VpcId": "vpc-1a2b3c4d",
+                        "InterfaceType": "interface"
+                    }
+                ],
+                "RootDeviceName": "/dev/xvda",
+                "RootDeviceType": "ebs",
+                "SecurityGroups": [
+                    {
+                        "GroupName": "MySecurityGroup",
+                        "GroupId": "sg-903004f8"
+                    }
+                ],
+                "SourceDestCheck": true,
+                "StateReason": {
+                    "Code": "pending",
+                    "Message": "pending"
+                },
+                "Tags": [],
+                "VirtualizationType": "hvm",
+                "CpuOptions": {
+                    "CoreCount": 1,
+                    "ThreadsPerCore": 1
+                },
+                "CapacityReservationSpecification": {
+                    "CapacityReservationPreference": "open"
+                },
+                "MetadataOptions": {
+                    "State": "pending",
+                    "HttpTokens": "optional",
+                    "HttpPutResponseHopLimit": 1,
+                    "HttpEndpoint": "enabled"
+                }
+            }
+        ],
+        "OwnerId": "123456789012",
+        "ReservationId": "r-5875ca20"
+    }
+
+**Example 4: To wait until the instance is running**
+
+The following ``wait instance-running`` example pauses until the instance is running. It produces no output. ::
+
+    aws ec2 wait instance-running \
+        --instance-ids i-5203422c
+
+**Example 5: To verify the instance is using the key pair**
+
+The following ``describe-instances`` example queries the instance to confirm the key pair name and running state. ::
+
+    aws ec2 describe-instances \
+        --instance-ids i-5203422c \
+        --query "Reservations[0].Instances[0].{InstanceId:InstanceId,KeyName:KeyName,State:State.Name}"
+
+Output::
+
+    {
+        "InstanceId": "i-5203422c",
+        "KeyName": "MyKeyPair",
+        "State": "running"
+    }
+
+**Example 6: To stop the instance**
+
+The following ``stop-instances`` example stops the running instance before cleanup. ::
+
+    aws ec2 stop-instances \
+        --instance-ids i-5203422c
+
+Output::
+
+    {
+        "StoppingInstances": [
+            {
+                "InstanceId": "i-5203422c",
+                "CurrentState": {
+                    "Code": 64,
+                    "Name": "stopping"
+                },
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ]
+    }
+
+**Example 7: To wait until the instance is stopped**
+
+The following ``wait instance-stopped`` example pauses until the instance is fully stopped. It produces no output. ::
+
+    aws ec2 wait instance-stopped \
+        --instance-ids i-5203422c
+
+**Example 8: To terminate the instance**
+
+The following ``terminate-instances`` example terminates the stopped instance. ::
+
+    aws ec2 terminate-instances \
+        --instance-ids i-5203422c
+
+Output::
+
+    {
+        "TerminatingInstances": [
+            {
+                "InstanceId": "i-5203422c",
+                "CurrentState": {
+                    "Code": 32,
+                    "Name": "shutting-down"
+                },
+                "PreviousState": {
+                    "Code": 80,
+                    "Name": "stopped"
+                }
+            }
+        ]
+    }
+
+**Example 9: To delete the key pair**
+
+The following ``delete-key-pair`` example deletes the key pair after the instance is terminated. ::
+
+    aws ec2 delete-key-pair \
+        --key-name MyKeyPair
+
+Output::
+
+    {
+        "Return": true,
+        "KeyPairId": "key-0b94643da6EXAMPLE"
+    }

--- a/emulators/aws-ec2/tests/cli/ec2/vpc-subnet-setup.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/vpc-subnet-setup.rst
@@ -1,0 +1,121 @@
+**Example 1: To create a VPC**
+
+The following ``create-vpc`` example creates a VPC with the specified IPv4 CIDR block and a Name tag. ::
+
+    aws ec2 create-vpc \
+        --cidr-block 10.0.0.0/16 \
+        --tag-specifications ResourceType=vpc,Tags=[{Key=Name,Value=MyVpc}]
+
+Output::
+
+    {
+        "Vpc": {
+            "CidrBlock": "10.0.0.0/16",
+            "DhcpOptionsId": "dopt-5EXAMPLE",
+            "State": "pending",
+            "VpcId": "vpc-0a60eb65b4EXAMPLE",
+            "OwnerId": "123456789012",
+            "InstanceTenancy": "default",
+            "Ipv6CidrBlockAssociationSet": [],
+            "CidrBlockAssociationSet": [
+                {
+                    "AssociationId": "vpc-cidr-assoc-07501b79ecEXAMPLE",
+                    "CidrBlock": "10.0.0.0/16",
+                    "CidrBlockState": {
+                        "State": "associated"
+                    }
+                }
+            ],
+            "IsDefault": false,
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "MyVpc"
+                }
+            ]
+        }
+    }
+
+**Example 2: To create an internet gateway**
+
+The following ``create-internet-gateway`` example creates an internet gateway with a Name tag. ::
+
+    aws ec2 create-internet-gateway \
+        --tag-specifications ResourceType=internet-gateway,Tags=[{Key=Name,Value=my-igw}]
+
+Output::
+
+    {
+        "InternetGateway": {
+            "Attachments": [],
+            "InternetGatewayId": "igw-0d0fb496b3994d755",
+            "OwnerId": "123456789012",
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "my-igw"
+                }
+            ]
+        }
+    }
+
+**Example 3: To attach the internet gateway to the VPC**
+
+The following ``attach-internet-gateway`` example attaches the internet gateway to the specified VPC. ::
+
+    aws ec2 attach-internet-gateway \
+        --internet-gateway-id igw-0d0fb496b3994d755 \
+        --vpc-id vpc-0a60eb65b4EXAMPLE
+
+**Example 4: To verify the internet gateway is attached to the VPC**
+
+The following ``describe-internet-gateways`` example queries the specified internet gateway's attachment to verify that it is attached to the VPC. ::
+
+    aws ec2 describe-internet-gateways \
+        --internet-gateway-ids igw-0d0fb496b3994d755 \
+        --query "InternetGateways[0].Attachments"
+
+Output::
+
+    [
+        {
+            "State": "available",
+            "VpcId": "vpc-0a60eb65b4EXAMPLE"
+        }
+    ]
+
+**Example 5: To create a subnet in the VPC**
+
+The following ``create-subnet`` example creates a subnet in the specified VPC with the specified IPv4 CIDR block. ::
+
+    aws ec2 create-subnet \
+        --vpc-id vpc-0a60eb65b4EXAMPLE \
+        --cidr-block 10.0.0.0/24 \
+        --tag-specifications ResourceType=subnet,Tags=[{Key=Name,Value=my-subnet}]
+
+Output::
+
+    {
+        "Subnet": {
+            "AvailabilityZone": "us-east-1a",
+            "AvailabilityZoneId": "use1-az1",
+            "AvailableIpAddressCount": 251,
+            "CidrBlock": "10.0.0.0/24",
+            "DefaultForAz": false,
+            "MapPublicIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-0e99b93155EXAMPLE",
+            "VpcId": "vpc-0a60eb65b4EXAMPLE",
+            "OwnerId": "123456789012",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "my-subnet"
+                }
+            ],
+            "SubnetArn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-0e99b93155EXAMPLE"
+        }
+    }
+

--- a/emulators/aws-ec2/tests/cli/ec2/working-with-security-groups.rst
+++ b/emulators/aws-ec2/tests/cli/ec2/working-with-security-groups.rst
@@ -1,0 +1,113 @@
+**Example 1: To create a security group for a VPC**
+
+The following ``create-security-group`` example creates a security group for the specified VPC. ::
+
+    aws ec2 create-security-group \
+        --group-name my-sg \
+        --description "My security group" \
+        --vpc-id vpc-1a2b3c4d
+
+Output::
+
+    {
+        "GroupId": "sg-903004f8"
+    }
+
+**Example 2: To describe a security group**
+
+The following ``describe-security-groups`` example describes the specified security group. ::
+
+    aws ec2 describe-security-groups \
+        --group-ids sg-903004f8
+
+Output::
+
+    {
+        "SecurityGroups": [
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ],
+                        "UserIdGroupPairs": []
+                    }
+                ],
+                "Description": "My security group",
+                "IpPermissions": [],
+                "GroupName": "my-sg",
+                "VpcId": "vpc-1a2b3c4d",
+                "OwnerId": "123456789012",
+                "GroupId": "sg-903004f8"
+            }
+        ]
+    }
+
+**Example 3: To add a rule that allows inbound RDP traffic**
+
+The following ``authorize-security-group-ingress`` example adds a rule that allows inbound traffic on TCP port 3389 (RDP) from the specified IP address. ::
+
+    aws ec2 authorize-security-group-ingress \
+        --group-id sg-903004f8 \
+        --protocol tcp \
+        --port 3389 \
+        --cidr x.x.x.x/x
+
+**Example 4: To add a rule that allows inbound SSH traffic**
+
+The following ``authorize-security-group-ingress`` example adds a rule that allows inbound traffic on TCP port 22 (SSH) from the specified IP address. ::
+
+    aws ec2 authorize-security-group-ingress \
+        --group-id sg-903004f8 \
+        --protocol tcp \
+        --port 22 \
+        --cidr x.x.x.x/x
+
+**Example 5: To describe a security group after adding inbound rules**
+
+The following ``describe-security-groups`` example describes the specified security group after adding inbound rules. ::
+
+    aws ec2 describe-security-groups \
+        --group-ids sg-903004f8
+
+Output::
+
+    {
+        "SecurityGroups": [
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ],
+                        "UserIdGroupPairs": []
+                    }
+                ],
+                "Description": "My security group",
+                "IpPermissions": [
+                    {
+                        "ToPort": 22,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "x.x.x.x/x"
+                            }
+                        ],
+                        "UserIdGroupPairs": [],
+                        "FromPort": 22
+                    }
+                ],
+                "GroupName": "my-sg",
+                "OwnerId": "123456789012",
+                "GroupId": "sg-903004f8"
+            }
+        ]
+    }
+
+For more information, see `Creating, configuring, and deleting Amazon EC2 security groups in the AWS CLI <https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-sg.html>`


### PR DESCRIPTION
 Adds 8 CLI test case files covering common AWS EC2 workflows:

   - **`ebs-volume-lifecycle.rst`** — Full EBS volume lifecycle: launch instance, create volume, attach/detach, modify, and delete
   - **`ebs-encryption-lifecycle.rst`** — EBS encryption: enable encryption by default, create encrypted volume, copy encrypted snapshots
   - **`key-pair-instance-lifecycle.rst`** — Key pair and instance lifecycle: create key pair, run/start/stop/terminate instances
   - **`filter-instances-found.rst`** — Instance filtering with results returned (by state, tag, type, etc.)
   - **`filter-instances-not-found.rst`** — Instance filtering with no results (empty response handling)
   - **`filter-instances-query.rst`** — Instance filtering using `--query` to extract specific fields
   - **`vpc-subnet-setup.rst`** — VPC and subnet setup: create VPC, create subnet, attach internet gateway, configure route table
   - **`working-with-security-groups.rst`** — Security group management: create, authorize ingress/egress rules, describe, and delete