### PR TITLE
Add Terraform test cases: 05-vpc-with-subnet, 06-instance-in-vpc

### DIFF
--- a/emulators/aws-ec2/tests/tf/05-vpc-with-subnet/main.tf
+++ b/emulators/aws-ec2/tests/tf/05-vpc-with-subnet/main.tf
@@ -1,0 +1,34 @@
+# Configure the AWS provider (endpoint set by terlocal when running against Vera)
+provider "aws" {
+  region = "us-east-1"
+}
+
+# VPC for EC2 resources
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "vera-tf-test-vpc"
+  }
+}
+
+# Public subnet in the VPC
+resource "aws_subnet" "public" {
+  vpc_id            = "${aws_vpc.main.id}"
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "vera-tf-test-subnet"
+  }
+}
+
+# Outputs for verification
+output "vpc_id" {
+  value = "${aws_vpc.main.id}"
+}
+
+output "subnet_id" {
+  value = "${aws_subnet.public.id}"
+}

--- a/emulators/aws-ec2/tests/tf/06-instance-in-vpc/main.tf
+++ b/emulators/aws-ec2/tests/tf/06-instance-in-vpc/main.tf
@@ -1,0 +1,61 @@
+# Configure the AWS provider (endpoint set by terlocal when running against Vera)
+provider "aws" {
+  region = "us-east-1"
+}
+
+# VPC and subnet for the instance
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "vera-tf-instance-vpc"
+  }
+}
+
+resource "aws_subnet" "main" {
+  vpc_id            = "${aws_vpc.main.id}"
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "vera-tf-instance-subnet"
+  }
+}
+
+# Security group for the instance
+resource "aws_security_group" "instance" {
+  name        = "vera-tf-instance-sg"
+  description = "Security group for Vera Terraform test instance"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "vera-tf-instance-sg"
+  }
+}
+
+# EC2 instance in VPC
+resource "aws_instance" "example" {
+  ami                    = "ami-785db401"
+  instance_type          = "t2.micro"
+  subnet_id              = "${aws_subnet.main.id}"
+  vpc_security_group_ids = ["${aws_security_group.instance.id}"]
+
+  tags = {
+    Name = "vera-tf-test-instance"
+  }
+}
+
+output "instance_id" {
+  value = "${aws_instance.example.id}"
+}
+
+output "private_ip" {
+  value = "${aws_instance.example.private_ip}"
+}


### PR DESCRIPTION
Add two Terraform test cases for Vera EC2 emulator:

- 05-vpc-with-subnet: VPC + one public subnet
- 06-instance-in-vpc: VPC + subnet + security group + EC2 instance

Both target the current Vera EC2 API (terlocal / localhost:5003). They may expose emulator gaps (e.g. DescribeVpcAttribute / enable_dns_hostnames) as expected for early-stage test cases.