### PR TITLE
Fix for the aws sdk CI test cases

### DIFF
--- a/emulators/aws-ec2/emulator_core/services/launchtemplate.py
+++ b/emulators/aws-ec2/emulator_core/services/launchtemplate.py
@@ -702,7 +702,7 @@ class LaunchTemplate_Backend:
         return f'{prefix}-{uuid.uuid4().hex[:17]}'
 
 from typing import Dict, List, Any, Optional
-from ..utils import get_scalar, get_int, get_indexed_list, parse_filters, parse_tags, str2bool, esc
+from ..utils import get_scalar, get_int, get_indexed_list, get_nested_dict, parse_filters, parse_tags, str2bool, esc
 from ..utils import is_error_response, serialize_error_response
 
 class launchtemplate_RequestParser:
@@ -711,7 +711,7 @@ class launchtemplate_RequestParser:
         return {
             "ClientToken": get_scalar(md, "ClientToken"),
             "DryRun": str2bool(get_scalar(md, "DryRun")),
-            "LaunchTemplateData": get_scalar(md, "LaunchTemplateData"),
+            "LaunchTemplateData": get_nested_dict(md, "LaunchTemplateData") or None,
             "LaunchTemplateName": get_scalar(md, "LaunchTemplateName"),
             "Operator": get_scalar(md, "Operator"),
             "TagSpecification.N": parse_tags(md, "TagSpecification"),
@@ -723,7 +723,7 @@ class launchtemplate_RequestParser:
         return {
             "ClientToken": get_scalar(md, "ClientToken"),
             "DryRun": str2bool(get_scalar(md, "DryRun")),
-            "LaunchTemplateData": get_scalar(md, "LaunchTemplateData"),
+            "LaunchTemplateData": get_nested_dict(md, "LaunchTemplateData") or None,
             "LaunchTemplateId": get_scalar(md, "LaunchTemplateId"),
             "LaunchTemplateName": get_scalar(md, "LaunchTemplateName"),
             "ResolveAlias": get_scalar(md, "ResolveAlias"),

--- a/emulators/aws-ec2/emulator_core/services/snapshot.py
+++ b/emulators/aws-ec2/emulator_core/services/snapshot.py
@@ -1384,13 +1384,7 @@ class snapshot_ResponseSerializer:
         if _fullSnapshotSizeInBytes_key:
             param_data = data[_fullSnapshotSizeInBytes_key]
             indent_str = "    " * 1
-            if param_data:
-                xml_parts.append(f'{indent_str}<fullSnapshotSizeInBytesSet>')
-                for item in param_data:
-                    xml_parts.append(f'{indent_str}    <item>{esc(str(item))}</item>')
-                xml_parts.append(f'{indent_str}</fullSnapshotSizeInBytesSet>')
-            else:
-                xml_parts.append(f'{indent_str}<fullSnapshotSizeInBytesSet/>')
+            xml_parts.append(f'{indent_str}<fullSnapshotSizeInBytes>{esc(str(param_data))}</fullSnapshotSizeInBytes>')
         # Serialize kmsKeyId
         _kmsKeyId_key = None
         if "kmsKeyId" in data:
@@ -1446,13 +1440,7 @@ class snapshot_ResponseSerializer:
         if _progress_key:
             param_data = data[_progress_key]
             indent_str = "    " * 1
-            if param_data:
-                xml_parts.append(f'{indent_str}<progressSet>')
-                for item in param_data:
-                    xml_parts.append(f'{indent_str}    <item>{esc(str(item))}</item>')
-                xml_parts.append(f'{indent_str}</progressSet>')
-            else:
-                xml_parts.append(f'{indent_str}<progressSet/>')
+            xml_parts.append(f'{indent_str}<progress>{esc(str(param_data))}</progress>')
         # Serialize restoreExpiryTime
         _restoreExpiryTime_key = None
         if "restoreExpiryTime" in data:
@@ -1462,7 +1450,8 @@ class snapshot_ResponseSerializer:
         if _restoreExpiryTime_key:
             param_data = data[_restoreExpiryTime_key]
             indent_str = "    " * 1
-            xml_parts.append(f'{indent_str}<restoreExpiryTime>{esc(str(param_data))}</restoreExpiryTime>')
+            if param_data:
+                xml_parts.append(f'{indent_str}<restoreExpiryTime>{esc(str(param_data))}</restoreExpiryTime>')
         # Serialize snapshotId
         _snapshotId_key = None
         if "snapshotId" in data:

--- a/emulators/aws-ec2/emulator_core/utils.py
+++ b/emulators/aws-ec2/emulator_core/utils.py
@@ -45,6 +45,26 @@ def get_scalar(params: RequestParams, key: str, default: Optional[str] = None) -
         return val[0] if val else default
     return val if val is not None else default
 
+def get_nested_dict(params: RequestParams, prefix: str) -> Dict[str, Any]:
+    """
+    Collect all dot-notation nested parameters into a dict.
+    E.g., for prefix='LaunchTemplateData', collects LaunchTemplateData.InstanceType,
+    LaunchTemplateData.ImageId, etc. into {'InstanceType': ..., 'ImageId': ...}.
+    """
+    result: Dict[str, Any] = {}
+    prefix_dot = prefix + "."
+    keys = params.keys() if hasattr(params, 'keys') else params.keys()
+    for key in keys:
+        if key.startswith(prefix_dot):
+            sub_key = key[len(prefix_dot):]
+            if sub_key:
+                val = params.getlist(key) if hasattr(params, 'getlist') else params.get(key)
+                if isinstance(val, list):
+                    result[sub_key] = val[0] if len(val) == 1 else val
+                else:
+                    result[sub_key] = val
+    return result
+
 def get_indexed_list(params: RequestParams, base: str) -> List[str]:
     """
     Extract a list of indexed parameters (e.g., InstanceId.1, InstanceId.2, ...).


### PR DESCRIPTION
* Added a new `get_nested_dict()` helper that parses dot-notation query 

* Fixed the `CreateLaunchTemplate` (and `CreateLaunchTemplateVersion`) request parser to use the new `get_nested_dict()` instead of `get_scalar()` for `LaunchTemplateData` 

* Fixed the XML serializer for `CreateSnapshot` responses

I've also added a github action to test the aws sdk in the project-vera/aws-testcases repo. This PR is going to fix the CI test.