### PR TITLE
feat: Add MVP script for running all Terraform test cases

### DIFF
--- a/emulators/aws-ec2/.gitignore
+++ b/emulators/aws-ec2/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 terraform.tfstate
 terraform.tfstate.backup
 _vera_override.tf
+tests/tf/runs/
 .bin/
 vera_aws.egg-info/
 eval_results*.json

--- a/emulators/aws-ec2/tests/tf/05-vpc-with-subnet/main.tf
+++ b/emulators/aws-ec2/tests/tf/05-vpc-with-subnet/main.tf
@@ -1,6 +1,12 @@
 # Configure the AWS provider (endpoint set by terlocal when running against Vera)
 provider "aws" {
   region = "us-east-1"
+
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
 }
 
 # VPC for EC2 resources

--- a/emulators/aws-ec2/tests/tf/06-instance-in-vpc/main.tf
+++ b/emulators/aws-ec2/tests/tf/06-instance-in-vpc/main.tf
@@ -1,6 +1,12 @@
 # Configure the AWS provider (endpoint set by terlocal when running against Vera)
 provider "aws" {
   region = "us-east-1"
+
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
 }
 
 # VPC and subnet for the instance

--- a/emulators/aws-ec2/tests/tf/README.md
+++ b/emulators/aws-ec2/tests/tf/README.md
@@ -1,0 +1,110 @@
+# Terraform test cases (Vera AWS EC2)
+
+This directory holds small Terraform configurations used to exercise the **Vera AWS EC2 emulator** and **LocalStack** without touching real AWS.
+
+**What counts as one testcase:** exactly one **direct child directory** of `tests/tf/` (for example `tests/tf/05-vpc-with-subnet/`). The driver does **not** treat deeper paths like `tests/tf/group/a-case/` as separate testcases—only the top-level folders under `tests/tf/` are candidates.
+
+**When that folder is included:** it must contain at least one `*.tf` or `*.tf.json` file **somewhere under that directory** (the file may live in a subfolder, e.g. `modules/foo/main.tf`). The driver searches recursively **inside** each top-level folder only—not across `tests/tf/` as a whole tree of testcases.
+
+---
+
+## Prerequisites
+
+- **Terraform** installed and on your `PATH` (`terraform -version`).
+- For **Vera**: from `emulators/aws-ec2/`, run `./install.sh` once so `terlocal` and `awscli` wrappers exist, then start the emulator:
+  ```bash
+  uv run main.py
+  ```
+  Default EC2 endpoint: `http://localhost:5003`.
+- For **LocalStack**: start your LocalStack instance (default EC2 endpoint: `http://localhost:4566`).
+
+---
+
+## Running tests with the driver script
+
+`run_terraform_tests.py` runs each testcase in a **temporary directory** (so `.terraform/` and state files are not left inside the testcase folders), injects a **provider override** for the chosen backend (see below), then runs:
+
+`terraform init` → `terraform apply -auto-approve` → `terraform destroy -auto-approve`
+
+Per-step logs and `summary.json` are written under `runs/<timestamp>/` (for example `runs/<timestamp>/vera-aws/05-vpc-with-subnet/apply.log` and `runs/<timestamp>/summary.json`). This directory is gitignored.
+
+From the repository root (you must pass **`--all`** or at least one **`--case`**; there is no default single testcase):
+
+```bash
+# One testcase against LocalStack
+python3 emulators/aws-ec2/tests/tf/run_terraform_tests.py --backend localstack --case 05-vpc-with-subnet
+
+# One testcase against Vera (emulator must be running)
+python3 emulators/aws-ec2/tests/tf/run_terraform_tests.py --backend vera-aws --case 06-instance-in-vpc
+
+# All testcases, both backends (start LocalStack and Vera first)
+python3 emulators/aws-ec2/tests/tf/run_terraform_tests.py --backend both --all
+```
+
+You can pass `--case` more than once to run several directories (for example `--case 05-vpc-with-subnet --case 06-instance-in-vpc`).
+
+If you omit `--backend`, it defaults to **`both`** (each testcase runs against LocalStack, then against Vera-AWS—start both services first).
+
+Optional flags:
+
+- `--trace` — sets `TF_LOG=TRACE` and writes per-step trace logs next to the other logs (see [Terraform debugging](https://developer.hashicorp.com/terraform/internals/debugging)).
+- `--timeout-s N` — per-step timeout in seconds (default `600`).
+- `--tf-root PATH` — alternate testcase root (defaults to this directory).
+
+---
+
+## Running tests manually (without the script)
+
+### Vera (`terlocal`)
+
+From `emulators/aws-ec2/`, after `./install.sh`, use **`terlocal`** instead of **`terraform`** inside a testcase directory. The `terlocal` wrapper exports dummy `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (and default region) before calling `terraform`. On first run it also creates `_vera_override.tf` in the **current working directory**, which adds a `provider "aws"` block with skip flags and `endpoints { ec2 = ... }` for the Vera endpoint (`VERA_ENDPOINT` at install time, default `http://localhost:5003`).
+
+```bash
+cd emulators/aws-ec2/tests/tf/00-simple-vpc
+uv run terlocal init
+uv run terlocal apply -auto-approve
+uv run terlocal destroy -auto-approve
+```
+
+Do not commit `_vera_override.tf` (it is listed in `emulators/aws-ec2/.gitignore`).
+
+### LocalStack or custom endpoints
+
+Point the AWS provider at LocalStack by adding your own override file or extra `provider "aws"` settings with `endpoints { ec2 = "http://localhost:4566" }` and dummy credentials / `skip_*` flags as needed.
+
+### Two styles of `provider "aws"` (both supported)
+
+Testcases in this folder are **not** required to look identical. Roughly:
+
+| Style | Example | What’s in `main.tf` |
+|--------|---------|---------------------|
+| **A — minimal** | `00-simple-vpc` … `04-one-webserver-with-vars` | Usually only `region = "..."` in `provider "aws"`. |
+| **B — inline emulator-friendly** | `05-vpc-with-subnet`, `06-instance-in-vpc` | `region` plus dummy `access_key` / `secret_key` and `skip_*` flags (still **no** `endpoints` in `main.tf`). |
+
+**`run_terraform_tests.py` handles both the same way:** it always adds `_backend_override.tf` in the temp copy, which supplies `endpoints { ec2 = ... }` (and repeats dummy creds / `skip_*` where needed). Terraform **merges** all default `provider "aws"` blocks into one configuration, so Style A and B both end up with a working endpoint for LocalStack or Vera. Style B is convenient when using **`terlocal`** by hand (fewer moving parts in a tiny example).
+
+---
+
+## How Terraform “override” files work
+
+Terraform loads configuration from `*.tf` and `*.tf.json` files in a working directory and **merges** them into one configuration. Files whose names end in **`_override.tf`** (or the legacy `override.tf`) are loaded **after** ordinary `.tf` / `.tf.json` files and are intended for **last-minute adjustments** without editing the main modules.
+
+You can use that to **layer local testing settings on top of the same `provider "aws"` block**:
+
+- **Same provider type, merged:** Multiple `provider "aws" { ... }` blocks without an `alias` are **merged** into one configuration. Later files can add or override attributes (for example `endpoints`, `skip_credentials_validation`).
+- **Why we use overrides for emulators:** Real AWS would use normal credentials and default endpoints. For Vera or LocalStack we need fake credentials, skip STS/account checks, and an `endpoints { ec2 = ... }` URL. Keeping that in `*_override.tf` (or generated files like `_vera_override.tf` / `_backend_override.tf`) makes it obvious what is **environment-specific** versus what is **shared testcase HCL**.
+
+In this repo:
+
+| Mechanism | When | What it adds |
+|-----------|------|----------------|
+| `_vera_override.tf` | Created by `terlocal` in the cwd when you run it | EC2 endpoint + `skip_*` flags for Vera (dummy AWS keys come from the wrapper’s environment, not this file) |
+| `_backend_override.tf` | Written by `run_terraform_tests.py` into the **temp** copy of a testcase | EC2 endpoint + dummy creds + skip flags for LocalStack or Vera (merged with whatever the testcase already declares) |
+
+Prefer **not** to commit `endpoints { ec2 = ... }` in testcase `main.tf` when it can be supplied by `terlocal` or the driver override; use dummy credentials only (never real AWS keys).
+
+---
+
+## See also
+
+- `emulators/aws-ec2/README.md` — Vera setup, `terlocal`, and CLI usage.

--- a/emulators/aws-ec2/tests/tf/run_terraform_tests.py
+++ b/emulators/aws-ec2/tests/tf/run_terraform_tests.py
@@ -56,16 +56,23 @@ def run(cmd: List[str], cwd: Path, env: Dict[str, str], timeout_s: int) -> Tuple
     return proc.returncode, proc.stdout, proc.stderr
 
 
+def _is_terraform_config_file(p: Path) -> bool:
+    if not p.is_file():
+        return False
+    name = p.name
+    return name.endswith(".tf") or name.endswith(".tf.json")
+
+
 def discover_cases(tf_root: Path) -> List[str]:
     """
     Each sub dir under tf_root is treated as one Terraform testcase.
-    We include a dir if it contains at least one *.tf file.
+    We include a dir if it contains at least one *.tf / *.tf.json file (any depth).
     """
     cases: List[str] = []
     for child in sorted(tf_root.iterdir()):
         if not child.is_dir():
             continue
-        if any(p.is_file() and p.suffix in {".tf", ".tf.json"} for p in child.rglob("*.tf*")):
+        if any(_is_terraform_config_file(p) for p in child.rglob("*")):
             cases.append(child.name)
     return cases
 

--- a/emulators/aws-ec2/tests/tf/run_terraform_tests.py
+++ b/emulators/aws-ec2/tests/tf/run_terraform_tests.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+Minimal Terraform test runner for Vera-AWS and LocalStack.
+
+This script iterates over Terraform testcase directories under `tests/tf/<case>/`,
+and for each backend runs the full lifecycle:
+  terraform init -> terraform apply -> terraform destroy
+
+To keep environments clean and avoid plugin/state accumulation, each testcase is
+copied into a temporary directory and executed there (temp dir is deleted after).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]  # emulators/aws-ec2/tests/tf -> emulators/aws-ec2 -> emulators -> repo
+DEFAULT_TF_ROOT = Path(__file__).resolve().parent
+
+
+@dataclass
+class BackendConfig:
+    name: str
+    ec2_endpoint: str
+
+
+BACKENDS: Dict[str, BackendConfig] = {
+    "localstack": BackendConfig(name="localstack", ec2_endpoint="http://localhost:4566"),
+    "vera-aws": BackendConfig(name="vera-aws", ec2_endpoint="http://localhost:5003"),
+}
+
+
+def run(cmd: List[str], cwd: Path, env: Dict[str, str], timeout_s: int) -> Tuple[int, str, str]:
+    # Do not set executable= here: with a argv list, overriding executable to bash
+    # makes the first arg ("terraform") be treated as a script path, breaking init/apply.
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def discover_cases(tf_root: Path) -> List[str]:
+    """
+    Each sub dir under tf_root is treated as one Terraform testcase.
+    We include a dir if it contains at least one *.tf file.
+    """
+    cases: List[str] = []
+    for child in sorted(tf_root.iterdir()):
+        if not child.is_dir():
+            continue
+        if any(p.is_file() and p.suffix in {".tf", ".tf.json"} for p in child.rglob("*.tf*")):
+            cases.append(child.name)
+    return cases
+
+
+def copy_case_to_temp(case_dir: Path, tmp_dir: Path) -> Path:
+    """
+    Copy the testcase contents into a temp working directory.
+    We intentionally do NOT copy Terraform state / plugins.
+    """
+
+    def ignore(src: str, names: List[str]) -> List[str]:
+        ignored: List[str] = []
+        for n in names:
+            if n == ".terraform" or n.startswith(".terraform/"):
+                ignored.append(n)
+                continue
+            if n == ".terraform.lock.hcl":
+                ignored.append(n)
+                continue
+            if n.startswith("terraform.tfstate"):
+                ignored.append(n)
+                continue
+            if n.endswith("_override.tf") or n.endswith("override.tf"):
+                ignored.append(n)
+                continue
+        return ignored
+
+    dest = tmp_dir / case_dir.name
+    shutil.copytree(str(case_dir), str(dest), ignore=ignore, dirs_exist_ok=False)
+    return dest
+
+
+def write_backend_override(tmp_case_dir: Path, backend: BackendConfig) -> Path:
+    """
+    Write a provider override file that:
+      - sets dummy credentials
+      - skips credential/account validation
+      - points EC2 endpoint to the selected backend
+
+    We do NOT set region, because testcase directories already declare it.
+    """
+    override_path = tmp_case_dir / "_backend_override.tf"
+    override_path.write_text(
+        "\n".join(
+            [
+                'provider "aws" {',
+                '  access_key                  = "test"',
+                '  secret_key                  = "test"',
+                "  skip_credentials_validation = true",
+                "  skip_metadata_api_check     = true",
+                "  skip_requesting_account_id  = true",
+                "",
+                "  endpoints {",
+                f'    ec2 = "{backend.ec2_endpoint}"',
+                "  }",
+                "}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return override_path
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run all Terraform testcases against LocalStack and/or Vera-AWS",
+    )
+    parser.add_argument(
+        "--tf-root",
+        type=Path,
+        default=DEFAULT_TF_ROOT,
+        help=f"Path to terraform testcases root (default: {DEFAULT_TF_ROOT})",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["localstack", "vera-aws", "both"],
+        default="both",
+        help="Which backend(s) to run against",
+    )
+    parser.add_argument(
+        "--case",
+        action="append",
+        default=[],
+        help="Run only the specified testcase directory name under tf-root (can be repeated)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run all discovered testcase directories under tf-root",
+    )
+    parser.add_argument(
+        "--timeout-s",
+        type=int,
+        default=600,
+        help="Timeout for terraform init/apply/destroy steps (seconds)",
+    )
+    parser.add_argument(
+        "--trace",
+        action="store_true",
+        help="Enable Terraform TRACE logs (TF_LOG=TRACE) for each step",
+    )
+
+    args = parser.parse_args()
+
+    tf_root: Path = args.tf_root
+    if not tf_root.exists():
+        print(f"Error: tf_root does not exist: {tf_root}", file=sys.stderr)
+        sys.exit(1)
+
+    discovered = discover_cases(tf_root)
+    if not discovered:
+        print(f"No testcase dirs discovered under: {tf_root}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.all:
+        cases = discovered
+    else:
+        cases = args.case
+        if not cases:
+            print("No testcases selected.", file=sys.stderr)
+            print(f"Discovered cases under {tf_root}: {', '.join(discovered)}", file=sys.stderr)
+            print("Use --all to run all, or --case <name> to run a specific one.", file=sys.stderr)
+            sys.exit(2)
+
+    if args.backend == "both":
+        backend_list = [BACKENDS["localstack"], BACKENDS["vera-aws"]]
+    else:
+        backend_list = [BACKENDS[args.backend]]
+
+    runs_dir = tf_root / "runs"
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_root = runs_dir / timestamp
+    ensure_dir(run_root)
+
+    results: List[Dict[str, object]] = []
+
+    for backend in backend_list:
+        for case in cases:
+            case_dir = tf_root / case
+            if not case_dir.exists():
+                print(f"Skipping missing testcase: {case_dir}", file=sys.stderr)
+                continue
+
+            print(f"\n==> Running testcase '{case}' on backend '{backend.name}'")
+
+            backend_dir = run_root / backend.name / case
+            ensure_dir(backend_dir)
+
+            t0 = time.time()
+
+            with tempfile.TemporaryDirectory(prefix=f"vera-tf-{backend.name}-{case}-") as tmp:
+                tmp_dir = Path(tmp)
+                tmp_case_dir = copy_case_to_temp(case_dir, tmp_dir)
+
+                # Inject provider endpoint override for this backend.
+                write_backend_override(tmp_case_dir, backend)
+
+                # Ensure we don't accidentally reuse cached .terraform from a previous run.
+                # (We already copied testcase without .terraform.)
+                env = os.environ.copy()
+                env["TF_IN_AUTOMATION"] = "1"
+                env["TF_INPUT"] = "0"
+
+                step_results: Dict[str, Dict[str, object]] = {}
+
+                def run_step(step: str, cmd: List[str]) -> None:
+                    step_log = backend_dir / f"{step}.log"
+                    step_env = env.copy()
+
+                    if args.trace:
+                        # Terraform will write its logs to TF_LOG_PATH.
+                        step_env["TF_LOG"] = "TRACE"
+                        step_env["TF_LOG_PATH"] = str(backend_dir / f"terraform_{step}.trace.log")
+
+                    print(f"  -> {step} ...")
+
+                    rc, stdout, stderr = run(cmd, cwd=tmp_case_dir, env=step_env, timeout_s=args.timeout_s)
+                    step_log.write_text(
+                        "".join(
+                            [
+                                f"COMMAND: {' '.join(cmd)}\n",
+                                f"RETURN_CODE: {rc}\n",
+                                "\nSTDOUT:\n",
+                                stdout,
+                                "\n\nSTDERR:\n",
+                                stderr,
+                                "\n",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    step_results[step] = {
+                        "return_code": rc,
+                        "log_file": str(step_log),
+                        "stdout_preview": stdout[:500],
+                        "stderr_preview": stderr[:500],
+                    }
+
+                run_step("init", ["terraform", "init", "-input=false", "-no-color"])
+                run_step("apply", ["terraform", "apply", "-auto-approve", "-input=false", "-no-color"])
+                run_step("destroy", ["terraform", "destroy", "-auto-approve", "-input=false", "-no-color"])
+
+                apply_ok = int(step_results["apply"]["return_code"]) == 0
+                destroy_ok = int(step_results["destroy"]["return_code"]) == 0
+
+            elapsed = time.time() - t0
+            passed = apply_ok and destroy_ok
+
+            results.append(
+                {
+                    "backend": backend.name,
+                    "case": case,
+                    "passed": passed,
+                    "elapsed_s": round(elapsed, 2),
+                    "steps": step_results,
+                }
+            )
+
+            print(f"==> Done: passed={passed} (apply_ok={apply_ok}, destroy_ok={destroy_ok})")
+
+    summary_path = run_root / "summary.json"
+    summary_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
+
+    total = len(results)
+    passed = sum(1 for r in results if r.get("passed") is True)
+    print("\n" + "=" * 80)
+    print("Terraform test run summary")
+    print("=" * 80)
+    print(f"Total: {total}")
+    print(f"Passed: {passed}")
+    print(f"Failed: {total - passed}")
+    print(f"Summary: {summary_path}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
Minimal Python script to run all Terraform testcases under `emulators/aws-ec2/tests/tf/` against **LocalStack** and **Vera-AWS** (issue #28).

## Behavior
- Each subdirectory under `tests/tf/` with `*.tf` / `*.tf.json` is one testcase (`--case <name>` or `--all`).
- Per testcase + backend: `terraform init` → `apply -auto-approve` → `destroy -auto-approve`.
- Runs in a **temp directory** so `.terraform/` and state don’t accumulate in the repo; outputs go to `tests/tf/runs/<timestamp>/` (ignored in `.gitignore`).

Prereqs: LocalStack and/or Vera emulator must already be running (`localhost:4566` / `localhost:5003`).

- Test Details:
```
python3 emulators/aws-ec2/tests/tf/run_terraform_tests.py --backend localstack --all
```

```
==> Running testcase '00-simple-vpc' on backend 'localstack'
  -> init ...
  -> apply ...
  -> destroy ...
==> Done: passed=True (apply_ok=True, destroy_ok=True)

==> Running testcase '01-hello-world' on backend 'localstack'
  -> init ...
  -> apply ...
  -> destroy ...
==> Done: passed=True (apply_ok=True, destroy_ok=True)

==> Running testcase '02-one-server' on backend 'localstack'
  -> init ...
  -> apply ...
  -> destroy ...
==> Done: passed=False (apply_ok=False, destroy_ok=False)

==> Running testcase '03-one-webserver' on backend 'localstack'
  -> init ...
  -> apply ...
  -> destroy ...
==> Done: passed=False (apply_ok=False, destroy_ok=False)

==> Running testcase '04-one-webserver-with-vars' on backend 'localstack'
  -> init ...
  -> apply ...
  -> destroy ...
==> Done: passed=False (apply_ok=False, destroy_ok=False)

==> Running testcase '05-vpc-with-subnet' on backend 'localstack'
  -> init ...
  -> apply ...
  -> destroy ...
==> Done: passed=True (apply_ok=True, destroy_ok=True)

==> Running testcase '06-instance-in-vpc' on backend 'localstack'
  -> init ...
  -> apply ...
  -> destroy ...
==> Done: passed=True (apply_ok=True, destroy_ok=True)

================================================================================
Terraform test run summary
================================================================================
Total: 7
Passed: 4
Failed: 3
Summary: /Users/junjieli/workplace/vera/emulators/aws-ec2/tests/tf/runs/20260323-005209/summary.json
```

Related to #28
